### PR TITLE
UWB Client Server communication

### DIFF
--- a/coap_client/src/coap_client.c
+++ b/coap_client/src/coap_client.c
@@ -48,7 +48,7 @@ static void on_nus_received(struct bt_conn *conn, const uint8_t *const data,
 		break;
 
 	default:
-		LOG_WRN("Received invalid data from NUS");
+		coap_client_send_uwb_request(data);
 	}
 }
 

--- a/coap_client/src/coap_client_utils.c
+++ b/coap_client/src/coap_client_utils.c
@@ -32,6 +32,7 @@ static struct k_work on_disconnect_work;
 mtd_mode_toggle_cb_t on_mtd_mode_toggle;
 
 /* Options supported by the server */
+static const char *const uwb_option[] = { UWB_URI_PATH, NULL };
 static const char *const light_option[] = { LIGHT_URI_PATH, NULL };
 static const char *const provisioning_option[] = { PROVISIONING_URI_PATH,
 						   NULL };
@@ -288,5 +289,20 @@ void coap_client_toggle_minimal_sleepy_end_device(void)
 {
 	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
 		k_work_submit(&toggle_MTD_SED_work);
+	}
+}
+
+void coap_client_send_uwb_request(uint8_t *const data)
+{
+	if (unique_local_addr.sin6_addr.s6_addr16[0] == 0) {
+		LOG_INF("Send multicast mesh 'uwb' request");
+		coap_send_request(COAP_METHOD_PUT,
+				  (const struct sockaddr *)&multicast_local_addr,
+				  uwb_option, data, sizeof(data), NULL);
+	} else {
+		LOG_INF("Send unicast 'uwb' request to: %s", unique_local_addr_str);
+		coap_send_request(COAP_METHOD_PUT,
+				  (const struct sockaddr *)&unique_local_addr,
+				  uwb_option, data, sizeof(data), NULL);
 	}
 }

--- a/coap_client/src/coap_client_utils.h
+++ b/coap_client/src/coap_client_utils.h
@@ -61,6 +61,12 @@ void coap_client_send_provisioning_request(void);
  */
 void coap_client_toggle_minimal_sleepy_end_device(void);
 
+/** @brief Send data to the CoAP server.
+ *
+ * @param[in] data Pointer to the data to be sent.
+ */
+void coap_client_send_uwb_request(uint8_t *const data);
+
 #endif
 
 /**

--- a/coap_server/interface/coap_server_client_interface.h
+++ b/coap_server/interface/coap_server_client_interface.h
@@ -18,5 +18,6 @@ enum light_command {
 
 #define PROVISIONING_URI_PATH "provisioning"
 #define LIGHT_URI_PATH "light"
+#define UWB_URI_PATH "uwb"
 
 #endif

--- a/coap_server/src/ot_coap_utils.c
+++ b/coap_server/src/ot_coap_utils.c
@@ -17,6 +17,9 @@
 
 LOG_MODULE_REGISTER(ot_coap_utils, CONFIG_OT_COAP_UTILS_LOG_LEVEL);
 
+char data[30];
+uint16_t data_length = 0;
+
 struct server_context {
 	struct otInstance *ot;
 	bool provisioning_enabled;
@@ -159,11 +162,13 @@ static void coap_default_handler(void *context, otMessage *message,
 				 const otMessageInfo *message_info)
 {
 	ARG_UNUSED(context);
-	ARG_UNUSED(message);
 	ARG_UNUSED(message_info);
 
-	LOG_INF("Received CoAP message that does not match any request "
-		"or resource");
+	data_length = otMessageRead(message, otMessageGetOffset(message), data,
+				    sizeof(data));
+	data[data_length] = '\0';
+
+	LOG_INF("Received 'uwb' data: %s", data);
 }
 
 void ot_coap_activate_provisioning(void)

--- a/connecta.code-workspace
+++ b/connecta.code-workspace
@@ -23,5 +23,13 @@
 		"explorer.openEditors.visible": 0,
 		"workbench.colorTheme": "Default High Contrast",
 		"zenMode.silentNotifications": false,
+		"files.associations": {
+			"coap_client_utils.h": "c",
+			"limits": "c",
+			"functional": "c",
+			"tuple": "c",
+			"*.tcc": "c",
+			"string": "c"
+		},
 	}
 }


### PR DESCRIPTION
- Send UWB data through BLE to Client
- Transfer UWB BLE data to Server through Thread
- Use Multicast as a default messaging mode
- Use Unicast when a server is provisioned specifically with the Client